### PR TITLE
Add comment syntax settings

### DIFF
--- a/settings/dot.cson
+++ b/settings/dot.cson
@@ -1,0 +1,3 @@
+'.source.dot':
+  'editor':
+    'commentStart': '# '

--- a/settings/sequence.cson
+++ b/settings/sequence.cson
@@ -1,0 +1,3 @@
+'.source.flowchart':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
This PR adds the specific comment syntax for both `sequence` and `dot` grammars.

fixes #16 